### PR TITLE
Add options to not print the GPU driver info & to set the recipe path

### DIFF
--- a/scripts/jenkins-build.sh
+++ b/scripts/jenkins-build.sh
@@ -30,8 +30,16 @@ echo CCPi build
 echo called with arguments: $@
 echo CCPI_BUILD_ARGS: $CCPI_BUILD_ARGS
 
-#print GPU driver info
-nvidia-smi
+# If NO_GUI = false then don't print GPU driver info
+if [[ ! -n ${NO_GUI} ]]
+then
+  nvidia-smi
+else
+    if [ ${NO_GUI} = false ]
+    then
+        nvidia-smi
+    fi 
+fi
 
 # define $RELEASE=0 if not defined. This means that if you pass the variable RELEASE=1 this script will checkout
 # the latest tag and build and upload that version.

--- a/scripts/jenkins-build.sh
+++ b/scripts/jenkins-build.sh
@@ -26,7 +26,7 @@
 # - some commit can be explicitly tagged including '_' char and something after, then it is considered as 'dev' version
 # CCPI_CONDA_TOKEN - token to upload binary builds to anaconda 
 # - it detects the branch under which the CCPi is build, master is uploaded to anaconda channel, non-master branch isn't
-# NO_GUI - if set to true, GPU driver information is not printed
+# NO_GPU - if set to true, GPU driver information is not printed
 # RECIPE_PATH - if set, uses this as the path to the conda recipe instead of Wrappers/Python/conda-recipe
 echo CCPi build 
 echo called with arguments: $@

--- a/scripts/jenkins-build.sh
+++ b/scripts/jenkins-build.sh
@@ -35,6 +35,10 @@ if [[ ! -n ${NO_GUI} ]] || [ ${NO_GUI} = false ]; then
   nvidia-smi
 fi
 
+if [[ ! -n ${RECIPE_PATH} ]] ; then
+  export RECIPE_PATH=Wrappers/Python/conda-recipe
+fi
+
 # define $RELEASE=0 if not defined. This means that if you pass the variable RELEASE=1 this script will checkout
 # the latest tag and build and upload that version.
 if [[ ! -n ${RELEASE} ]] ; then
@@ -111,8 +115,8 @@ else
 fi
 # need to call first build
 
-if [[ -d Wrappers/Python/conda-recipe ]]; then
-  eval conda build Wrappers/Python/conda-recipe "$CCPI_BUILD_ARGS" "$@"
+if [[ -d ${RECIPE_PATH} ]]; then
+  eval conda build ${RECIPE_PATH} "$CCPI_BUILD_ARGS" "$@"
   # call with --output generates the files being created
   #export REG_FILES=$REG_FILES`eval conda build Wrappers/Python/conda-recipe "$CCPI_BUILD_ARGS" --output`$'\n'
   #--output bug work around

--- a/scripts/jenkins-build.sh
+++ b/scripts/jenkins-build.sh
@@ -31,14 +31,8 @@ echo called with arguments: $@
 echo CCPI_BUILD_ARGS: $CCPI_BUILD_ARGS
 
 # If NO_GUI = false then don't print GPU driver info
-if [[ ! -n ${NO_GUI} ]]
-then
+if [[ ! -n ${NO_GUI} ]] || [ ${NO_GUI} = false ]; then
   nvidia-smi
-else
-    if [ ${NO_GUI} = false ]
-    then
-        nvidia-smi
-    fi 
 fi
 
 # define $RELEASE=0 if not defined. This means that if you pass the variable RELEASE=1 this script will checkout

--- a/scripts/jenkins-build.sh
+++ b/scripts/jenkins-build.sh
@@ -30,7 +30,7 @@ echo CCPi build
 echo called with arguments: $@
 echo CCPI_BUILD_ARGS: $CCPI_BUILD_ARGS
 
-# If NO_GUI = false then don't print GPU driver info
+# If NO_GUI = true then don't print GPU driver info
 if [[ ! -n ${NO_GUI} ]] || [ ${NO_GUI} = false ]; then
   nvidia-smi
 fi

--- a/scripts/jenkins-build.sh
+++ b/scripts/jenkins-build.sh
@@ -26,6 +26,8 @@
 # - some commit can be explicitly tagged including '_' char and something after, then it is considered as 'dev' version
 # CCPI_CONDA_TOKEN - token to upload binary builds to anaconda 
 # - it detects the branch under which the CCPi is build, master is uploaded to anaconda channel, non-master branch isn't
+# NO_GUI - if set to true, GPU driver information is not printed
+# RECIPE_PATH - if set, uses this as the path to the conda recipe instead of Wrappers/Python/conda-recipe
 echo CCPi build 
 echo called with arguments: $@
 echo CCPI_BUILD_ARGS: $CCPI_BUILD_ARGS


### PR DESCRIPTION
If NO_GUI is set to true, the GPU driver info will not be printed. In all other cases (even if NO_GUI is not set) this info will be printed.

If RECIPE_PATH is set, it will build the recipe in this directory, otherwise it will build the recipe at: Wrappers/Python/conda-recipe