### PR TITLE
Test all on release test list on dev

### DIFF
--- a/scripts/jenkins-build.sh
+++ b/scripts/jenkins-build.sh
@@ -39,10 +39,10 @@ fi
 
 # set test Python and NumPy version
 if [[ ! -n ${TEST_PY} ]] ; then
-  export TEST_PY='3.6'
+  export TEST_PY=(3.8 3.8 3.10 3.10)
 fi
 if [[ ! -n ${TEST_NP} ]] ; then
-  export TEST_NP='1.15'
+  export TEST_NP=(1.21 1.23 1.21 1.23)
 fi
 
 if [[ ! -n ${RECIPE_PATH} ]] ; then
@@ -128,12 +128,22 @@ fi
 # need to call first build
 
 if [[ -d ${RECIPE_PATH} ]]; then
-  ##if >0 commit (some _ in version) then marking as dev build
   if [[ ${ncommits} == "0" ]]; then
+    # one release build and test all
     eval conda build ${RECIPE_PATH} "$CCPI_BUILD_ARGS" "$@"
   else
+    # first build all
     eval conda build --no-test ${RECIPE_PATH} "$CCPI_BUILD_ARGS" "$@"
-    eval conda build ${RECIPE_PATH} "$CCPI_BUILD_ARGS" "$@" --python=${TEST_PY} --numpy=${TEST_NP}
+    
+    #then build some with tests
+    for i in ${!TEST_PY[@]};
+    do
+      py_ver=${TEST_PY[$i]}
+      np_ver=${TEST_NP[$i]}
+
+      eval conda build ${RECIPE_PATH} "$CCPI_BUILD_ARGS" "$@" --python=${py_ver} --numpy=${np_ver}
+    done
+
   fi
   # call with --output generates the files being created
   #export REG_FILES=$REG_FILES`eval conda build Wrappers/Python/conda-recipe "$CCPI_BUILD_ARGS" --output`$'\n'

--- a/scripts/jenkins-build.sh
+++ b/scripts/jenkins-build.sh
@@ -154,10 +154,20 @@ fi
 if [[ -d recipe ]]; then
   ##if >0 commit (some _ in version) then marking as dev build
   if [[ ${ncommits} == "0" ]]; then
+    # one release build and test all
     eval conda build recipe "$CCPI_BUILD_ARGS" "$@"
   else
+    # first build all
     eval conda build --no-test recipe "$CCPI_BUILD_ARGS" "$@"
-    eval conda build recipe "$CCPI_BUILD_ARGS" "$@" --python=${TEST_PY} --numpy=${TEST_NP}
+    
+    #then rebuild some with tests
+    for i in ${!TEST_PY[@]};
+    do
+      py_ver=${TEST_PY[$i]}
+      np_ver=${TEST_NP[$i]}
+
+      eval conda build recipe "$CCPI_BUILD_ARGS" "$@" --python=${py_ver} --numpy=${np_ver}
+    done
   fi
   # call with --output generates the files being created
   #--output bug work around


### PR DESCRIPTION
This will test an array of versions passes set as:
export TEST_PY=(3.8 3.8 3.11 3.11)
export TEST_NP=(1.20 1.24 1.20 1.24)

For dev build we can pass a single version.

For a nightly master I recommend testing only oldest/newest combos i.e:

py version lowest, np version lowest
py version lowest, np version highest
py version highest, np version lowest
py version highest, np version lowest

And test all on release.

Currently the olders/newest combos have to be set manually but it would be nice for the script to autodetect them.

The script also builds all first, and then rebuilds those with tests, which is not ideal, but ok for now.